### PR TITLE
fix: resolve SIGILL error by updating platform and Bun version

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           context: .
           file: ./apps/api/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/${{ github.repository }}/viralkan-api:${{ needs.commit-hash.outputs.commit_hash }}
@@ -77,7 +77,7 @@ jobs:
         with:
           context: .
           file: ./apps/web/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           build-args: |
             NEXT_PUBLIC_FIREBASE_API_KEY=${{ vars.NEXT_PUBLIC_FIREBASE_API_KEY }}

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.2.4 AS base
+FROM oven/bun:1.2.6 AS base
 WORKDIR /app
 
 # Install wget for health checks (Debian-based official Bun image)

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.2.4 AS base
+FROM oven/bun:1.2.6 AS base
 
 # Install wget for health checks (Debian-based official Bun image)
 USER root


### PR DESCRIPTION
- Build only for linux/amd64 (not arm64) to match VPS architecture
- Update oven/bun from 1.2.4 to 1.2.6 for bug fixes
- CVE-2025-55182 and CVE-2025-66478 are already patched in current versions