### PR TITLE
fix: add reports_this_month to user stats API and align frontend types (#8)

### DIFF
--- a/apps/api/src/routes/auth/__tests__/auth.test.ts
+++ b/apps/api/src/routes/auth/__tests__/auth.test.ts
@@ -86,6 +86,98 @@ describe("Auth Core Logic Tests", () => {
   });
 });
 
+describe("User Stats reports_this_month Tests", () => {
+  test("reports_this_month counts only current calendar month reports", () => {
+    const now = new Date();
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+
+    // Simulate reports: 2 this month, 1 last month
+    const reports = [
+      { created_at: new Date(startOfMonth.getTime() + 1000) }, // this month
+      { created_at: new Date(startOfMonth.getTime() + 86400000) }, // this month
+      { created_at: new Date(startOfMonth.getTime() - 86400000) }, // last month
+    ];
+
+    const reportsThisMonth = reports.filter(
+      (r) => r.created_at >= startOfMonth,
+    ).length;
+
+    expect(reportsThisMonth).toBe(2);
+  });
+
+  test("reports_this_month is 0 when no reports in current month", () => {
+    const now = new Date();
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+
+    // All reports from last month
+    const reports = [
+      { created_at: new Date(startOfMonth.getTime() - 86400000) },
+      { created_at: new Date(startOfMonth.getTime() - 172800000) },
+    ];
+
+    const reportsThisMonth = reports.filter(
+      (r) => r.created_at >= startOfMonth,
+    ).length;
+
+    expect(reportsThisMonth).toBe(0);
+  });
+
+  test("getUserStats response includes reports_this_month field", () => {
+    const mockStatsResponse = {
+      total_reports: 5,
+      reports_this_month: 2,
+      reports_by_category: {
+        berlubang: 3,
+        retak: 1,
+        lainnya: 1,
+      },
+      last_report_date: new Date().toISOString(),
+      account_age_days: 45,
+    };
+
+    expect(typeof mockStatsResponse.reports_this_month).toBe("number");
+    expect(mockStatsResponse.reports_this_month).toBe(2);
+    expect(mockStatsResponse.reports_this_month).toBeLessThanOrEqual(
+      mockStatsResponse.total_reports,
+    );
+  });
+
+  test("getUserStats row mapping converts reports_this_month to number", () => {
+    // Simulate raw DB row (postgres returns counts as strings)
+    const rawRow = {
+      total_reports: "5",
+      reports_this_month: "2",
+      berlubang_count: "3",
+      retak_count: "1",
+      lainnya_count: "1",
+      last_report_date: null,
+      join_date: new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+
+    const mapped = {
+      total_reports: parseInt(rawRow.total_reports) || 0,
+      reports_this_month: parseInt(rawRow.reports_this_month) || 0,
+    };
+
+    expect(mapped.reports_this_month).toBe(2);
+    expect(typeof mapped.reports_this_month).toBe("number");
+  });
+
+  test("getUserStats row mapping defaults reports_this_month to 0 when null", () => {
+    const rawRow = {
+      total_reports: "0",
+      reports_this_month: null as string | null,
+    };
+
+    const mapped = {
+      total_reports: parseInt(rawRow.total_reports ?? "0") || 0,
+      reports_this_month: parseInt(rawRow.reports_this_month ?? "0") || 0,
+    };
+
+    expect(mapped.reports_this_month).toBe(0);
+  });
+});
+
 describe("Auth Route Response Format Tests", () => {
   test("error response format", () => {
     const errorResponse = {

--- a/apps/api/src/routes/auth/data.ts
+++ b/apps/api/src/routes/auth/data.ts
@@ -259,19 +259,21 @@ export const getUserStats = async (
   userId: string, // Changed from number to string (UUID v7)
 ): Promise<{
   total_reports: number;
+  reports_this_month: number;
   reports_by_category: { berlubang: number; retak: number; lainnya: number };
   last_report_date: Date | null;
   account_age_days: number;
 }> => {
   const getStats = `
-    SELECT 
+    SELECT
       COUNT(r.id) as total_reports,
+      COUNT(CASE WHEN r.created_at >= date_trunc('month', NOW()) THEN 1 END) as reports_this_month,
       COUNT(CASE WHEN r.category = 'berlubang' THEN 1 END) as berlubang_count,
       COUNT(CASE WHEN r.category = 'retak' THEN 1 END) as retak_count,
       COUNT(CASE WHEN r.category = 'lainnya' THEN 1 END) as lainnya_count,
       MAX(r.created_at) as last_report_date,
       u.created_at as join_date
-    FROM users u 
+    FROM users u
     LEFT JOIN reports r ON r.user_id = u.id
     WHERE u.id = $1
     GROUP BY u.id, u.created_at;
@@ -292,6 +294,7 @@ export const getUserStats = async (
 
   return {
     total_reports: parseInt(row.total_reports) || 0,
+    reports_this_month: parseInt(row.reports_this_month) || 0,
     reports_by_category: {
       berlubang: parseInt(row.berlubang_count) || 0,
       retak: parseInt(row.retak_count) || 0,

--- a/apps/api/src/routes/auth/shell.ts
+++ b/apps/api/src/routes/auth/shell.ts
@@ -284,6 +284,7 @@ export const getUserStats = async (
 ): Promise<
   AppResult<{
     total_reports: number;
+    reports_this_month: number;
     reports_by_category: { berlubang: number; retak: number; lainnya: number };
     last_report_date: string | null;
     account_age_days: number;
@@ -338,6 +339,7 @@ export const getUserStats = async (
     // Transform data for response (convert Date to ISO string)
     const responseStats = {
       total_reports: stats.total_reports,
+      reports_this_month: stats.reports_this_month,
       reports_by_category: stats.reports_by_category,
       last_report_date: stats.last_report_date
         ? stats.last_report_date.toISOString()

--- a/apps/api/src/routes/auth/shell.ts
+++ b/apps/api/src/routes/auth/shell.ts
@@ -1,5 +1,6 @@
 import type { Sql } from "postgres";
 import admin from "firebase-admin";
+import type { z } from "zod";
 import { getFirebaseAuth } from "../../config/firebase";
 import * as core from "./core";
 import * as data from "./data";
@@ -11,6 +12,7 @@ import type {
 } from "./types";
 import { createSuccess, createError } from "@/types";
 import type { AppResult } from "@/types";
+import type { UserStatsResponseSchema } from "@/schema/auth";
 
 /**
  * Verifies Firebase ID token and returns user data
@@ -281,15 +283,7 @@ export const getUserStats = async (
   sql: Sql,
   userId: string, // Changed from number to string (UUID v7)
   requestingUserId: string, // Changed from number to string (UUID v7)
-): Promise<
-  AppResult<{
-    total_reports: number;
-    reports_this_month: number;
-    reports_by_category: { berlubang: number; retak: number; lainnya: number };
-    last_report_date: string | null;
-    account_age_days: number;
-  }>
-> => {
+): Promise<AppResult<z.infer<typeof UserStatsResponseSchema>>> => {
   try {
     // Input validation
     if (!userId || typeof userId !== "string" || userId.trim().length === 0) {

--- a/apps/api/src/schema/auth.ts
+++ b/apps/api/src/schema/auth.ts
@@ -148,6 +148,10 @@ export const UserStatsResponseSchema = z.object({
     example: 15,
     description: "Total number of reports created by user",
   }),
+  reports_this_month: z.number().openapi({
+    example: 3,
+    description: "Number of reports created in the current calendar month",
+  }),
   reports_by_category: z
     .object({
       berlubang: z.number().openapi({ example: 8 }),

--- a/apps/web/components/sharing/share-dialog.tsx
+++ b/apps/web/components/sharing/share-dialog.tsx
@@ -15,6 +15,7 @@ import { Badge } from "@repo/ui/components/ui/badge";
 import { Loader2, Share2, CheckCircle, X, Brain } from "lucide-react";
 import { toast } from "sonner";
 import { useSharing } from "@/hooks/sharing";
+import type { GenerateAICaptionRequest } from "@/services/api-client";
 import {
   PlatformSelector,
   type Platform,
@@ -62,7 +63,7 @@ export function ShareDialog({
     const result = await generateAICaption(
       reportId,
       platform,
-      tone as "formal" | "urgent" | "community" | "informative",
+      tone as GenerateAICaptionRequest["tone"],
       true,
     );
 

--- a/apps/web/hooks/dashboard/use-dashboard-stats.ts
+++ b/apps/web/hooks/dashboard/use-dashboard-stats.ts
@@ -4,7 +4,9 @@ import { useAuthContext } from "../../contexts/AuthContext";
 export interface UserStats {
   total_reports: number;
   reports_this_month: number;
+  reports_by_category: { berlubang: number; retak: number; lainnya: number };
   last_report_date: string | null;
+  account_age_days: number;
 }
 
 /**

--- a/apps/web/lib/auth-server.ts
+++ b/apps/web/lib/auth-server.ts
@@ -22,7 +22,9 @@ interface AuthVerificationResponse {
 interface UserStatsResponse {
   total_reports: number;
   reports_this_month: number;
+  reports_by_category: { berlubang: number; retak: number; lainnya: number };
   last_report_date: string | null;
+  account_age_days: number;
 }
 
 export async function getAuthUser(): Promise<AuthUser | null> {


### PR DESCRIPTION
## Summary

- Fixes #8 — dashboard stat cards displaying blank for all signed-in users
- Root cause: API returned `reports_by_category` + `account_age_days` but frontend types expected `reports_this_month` (contract drift, not a missing endpoint)
- Adds `COUNT(CASE WHEN r.created_at >= date_trunc('month', NOW()) THEN 1 END) as reports_this_month` to the stats SQL query
- Extends `UserStatsResponseSchema` (Zod) with the new field — keeps all existing fields intact
- Aligns `UserStatsResponse` in `auth-server.ts` and `UserStats` in `use-dashboard-stats.ts` to match the full API shape (was also missing `reports_by_category` and `account_age_days`)
- Shell return type now derives from `z.infer<typeof UserStatsResponseSchema>` to eliminate schema/type drift risk

## What did NOT change

- No UI changes — dashboard page already referenced `stats?.reports_this_month`, it just received `undefined` at runtime
- No new API endpoints
- No breaking changes to existing fields

## Test plan

- [ ] Sign in → visit `/dashboard` → all three stat cards show real values (total reports, this month, last report date)
- [ ] User with zero reports → all cards show `0` / `—` gracefully
- [ ] User with reports only from previous months → "this month" card shows `0`
- [ ] `cd apps/api && bun test` → 73 tests pass (68 existing + 5 new)
- [ ] `bun run check-types && bun run lint` → no errors

## Notes

- Pre-existing `const row = result[0] as any` in `data.ts:getUserStats` is noted but not introduced by this PR — tracked separately
- Timezone note: `date_trunc('month', NOW())` uses the DB server's timezone; reports near midnight on the 1st may vary by ±7h in Jakarta — acceptable for v1 stats

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)