### PR TITLE
feat: add /peta density map with Leaflet circle markers (#30)

### DIFF
--- a/apps/web/app/peta/loading.tsx
+++ b/apps/web/app/peta/loading.tsx
@@ -1,0 +1,15 @@
+const PetaLoading = () => {
+  return (
+    <div
+      className="flex items-center justify-center bg-neutral-100"
+      style={{ height: "calc(100vh - 64px)" }}
+    >
+      <div className="flex flex-col items-center gap-3">
+        <div className="h-10 w-10 animate-spin rounded-full border-4 border-neutral-300 border-t-red-600" />
+        <p className="text-sm text-neutral-500">Memuat peta...</p>
+      </div>
+    </div>
+  );
+};
+
+export default PetaLoading;

--- a/apps/web/app/peta/map-client-wrapper.tsx
+++ b/apps/web/app/peta/map-client-wrapper.tsx
@@ -13,6 +13,10 @@ interface MapClientWrapperProps {
   reports: MapReport[];
 }
 
+/**
+ * Client-side wrapper that dynamically loads ReportsMap with SSR disabled.
+ * Receives pre-fetched reports from the server component and passes them to the map.
+ */
 export const MapClientWrapper = ({ reports }: MapClientWrapperProps) => {
   return <ReportsMap reports={reports} />;
 };

--- a/apps/web/app/peta/map-client-wrapper.tsx
+++ b/apps/web/app/peta/map-client-wrapper.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { MapReport } from "../../lib/maps/constants";
+import PetaLoading from "./loading";
+
+const ReportsMap = dynamic(() => import("../../components/maps/reports-map"), {
+  ssr: false,
+  loading: () => <PetaLoading />,
+});
+
+interface MapClientWrapperProps {
+  reports: MapReport[];
+}
+
+export const MapClientWrapper = ({ reports }: MapClientWrapperProps) => {
+  return <ReportsMap reports={reports} />;
+};

--- a/apps/web/app/peta/page.tsx
+++ b/apps/web/app/peta/page.tsx
@@ -4,51 +4,56 @@ import type { MapReport } from "../../lib/maps/constants";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
 
-const fetchMapReports = async (): Promise<MapReport[]> => {
-  const response = await fetch(`${API_BASE_URL}/api/reports?limit=1000`, {
-    method: "GET",
-    headers: { "Content-Type": "application/json" },
-    cache: "no-store",
-  });
+const isValidMapReport = (
+  item: unknown,
+): item is {
+  id: string;
+  lat: number;
+  lon: number;
+  category: "berlubang" | "retak" | "lainnya";
+  street_name: string;
+  image_url: string;
+  created_at: string;
+} =>
+  item !== null &&
+  typeof item === "object" &&
+  "lat" in item &&
+  "lon" in item &&
+  item.lat !== null &&
+  item.lon !== null &&
+  typeof (item as Record<string, unknown>).lat === "number" &&
+  typeof (item as Record<string, unknown>).lon === "number";
 
-  if (!response.ok) {
+const toMapReport = (item: {
+  id: string;
+  lat: number;
+  lon: number;
+  category: "berlubang" | "retak" | "lainnya";
+  street_name: string;
+  image_url: string;
+  created_at: string;
+}): MapReport => ({
+  id: item.id,
+  lat: item.lat,
+  lon: item.lon,
+  category: item.category,
+  street_name: item.street_name,
+  image_url: item.image_url,
+  created_at: item.created_at,
+});
+
+const fetchMapReports = async (): Promise<MapReport[]> => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/reports?limit=1000`, {
+      cache: "no-store",
+    });
+    if (!response.ok) return [];
+    const data = await response.json();
+    const items: unknown[] = Array.isArray(data?.items) ? data.items : [];
+    return items.filter(isValidMapReport).map(toMapReport);
+  } catch {
     return [];
   }
-
-  const data = await response.json();
-  const items: unknown[] = Array.isArray(data?.items) ? data.items : [];
-
-  return items
-    .filter(
-      (
-        item,
-      ): item is {
-        id: string;
-        lat: number;
-        lon: number;
-        category: "berlubang" | "retak" | "lainnya";
-        street_name: string;
-        image_url: string;
-        created_at: string;
-      } =>
-        item !== null &&
-        typeof item === "object" &&
-        "lat" in item &&
-        "lon" in item &&
-        item.lat !== null &&
-        item.lon !== null &&
-        typeof (item as Record<string, unknown>).lat === "number" &&
-        typeof (item as Record<string, unknown>).lon === "number",
-    )
-    .map((item) => ({
-      id: item.id,
-      lat: item.lat,
-      lon: item.lon,
-      category: item.category,
-      street_name: item.street_name,
-      image_url: item.image_url,
-      created_at: item.created_at,
-    }));
 };
 
 export default async function PetaPage() {

--- a/apps/web/app/peta/page.tsx
+++ b/apps/web/app/peta/page.tsx
@@ -1,0 +1,65 @@
+import Header from "components/layout/header";
+import { MapClientWrapper } from "./map-client-wrapper";
+import type { MapReport } from "../../lib/maps/constants";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
+
+const fetchMapReports = async (): Promise<MapReport[]> => {
+  const response = await fetch(`${API_BASE_URL}/api/reports?limit=1000`, {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    return [];
+  }
+
+  const data = await response.json();
+  const items: unknown[] = Array.isArray(data?.items) ? data.items : [];
+
+  return items
+    .filter(
+      (
+        item,
+      ): item is {
+        id: string;
+        lat: number;
+        lon: number;
+        category: "berlubang" | "retak" | "lainnya";
+        street_name: string;
+        image_url: string;
+        created_at: string;
+      } =>
+        item !== null &&
+        typeof item === "object" &&
+        "lat" in item &&
+        "lon" in item &&
+        item.lat !== null &&
+        item.lon !== null &&
+        typeof (item as Record<string, unknown>).lat === "number" &&
+        typeof (item as Record<string, unknown>).lon === "number",
+    )
+    .map((item) => ({
+      id: item.id,
+      lat: item.lat,
+      lon: item.lon,
+      category: item.category,
+      street_name: item.street_name,
+      image_url: item.image_url,
+      created_at: item.created_at,
+    }));
+};
+
+export default async function PetaPage() {
+  const reports = await fetchMapReports();
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <Header />
+      <main>
+        <MapClientWrapper reports={reports} />
+      </main>
+    </div>
+  );
+}

--- a/apps/web/components/layout/header.tsx
+++ b/apps/web/components/layout/header.tsx
@@ -162,6 +162,12 @@ const Header = () => {
               Laporan
             </Link>
             <Link
+              href="/peta"
+              className="border-b-2 border-transparent px-1 py-2 text-sm font-medium text-neutral-600 transition-colors hover:border-neutral-300 hover:text-neutral-900"
+            >
+              Peta
+            </Link>
+            <Link
               href="/#how-it-works"
               className="border-b-2 border-transparent px-1 py-2 text-sm font-medium text-neutral-600 transition-colors hover:border-neutral-300 hover:text-neutral-900"
             >

--- a/apps/web/components/maps/density-dots-layer.tsx
+++ b/apps/web/components/maps/density-dots-layer.tsx
@@ -21,6 +21,10 @@ interface DensityDotsLayerProps {
   reports: MapReport[];
 }
 
+/**
+ * Renders road damage reports as circle markers on the Leaflet map.
+ * Culls markers to the current viewport on each pan or zoom to limit DOM nodes.
+ */
 export const DensityDotsLayer = ({ reports }: DensityDotsLayerProps) => {
   const map = useMap();
   const [bounds, setBounds] = useState<LatLngBounds>(() => map.getBounds());
@@ -30,10 +34,8 @@ export const DensityDotsLayer = ({ reports }: DensityDotsLayerProps) => {
   useEffect(() => {
     const updateBounds = () => setBounds(map.getBounds());
     map.on("moveend", updateBounds);
-    map.on("zoomend", updateBounds);
     return () => {
       map.off("moveend", updateBounds);
-      map.off("zoomend", updateBounds);
     };
   }, [map]);
 

--- a/apps/web/components/maps/density-dots-layer.tsx
+++ b/apps/web/components/maps/density-dots-layer.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useMap } from "react-leaflet";
+import { renderToString } from "react-dom/server";
+import L from "leaflet";
+import type {
+  CircleMarker as LeafletCircleMarker,
+  LatLngBounds,
+} from "leaflet";
+import {
+  CATEGORY_COLORS,
+  DOT_OPACITY,
+  DOT_RADIUS,
+  type MapReport,
+} from "../../lib/maps/constants";
+import { filterReportsInBounds } from "../../lib/maps/viewport-filter";
+import { ReportPopup } from "./report-popup";
+
+interface DensityDotsLayerProps {
+  reports: MapReport[];
+}
+
+export const DensityDotsLayer = ({ reports }: DensityDotsLayerProps) => {
+  const map = useMap();
+  const [bounds, setBounds] = useState<LatLngBounds>(() => map.getBounds());
+  const markersRef = useRef<LeafletCircleMarker[]>([]);
+
+  // Update bounds on map move/zoom
+  useEffect(() => {
+    const updateBounds = () => setBounds(map.getBounds());
+    map.on("moveend", updateBounds);
+    map.on("zoomend", updateBounds);
+    return () => {
+      map.off("moveend", updateBounds);
+      map.off("zoomend", updateBounds);
+    };
+  }, [map]);
+
+  // Viewport-culled reports
+  const visibleReports = useMemo(
+    () => filterReportsInBounds(reports, bounds),
+    [reports, bounds],
+  );
+
+  // Render circle markers imperatively
+  useEffect(() => {
+    // Remove previous markers
+    markersRef.current.forEach((marker) => marker.remove());
+    markersRef.current = [];
+
+    visibleReports.forEach((report) => {
+      const color = CATEGORY_COLORS[report.category] ?? "#ef4444";
+      const marker = L.circleMarker([report.lat, report.lon], {
+        radius: DOT_RADIUS,
+        fillColor: color,
+        fillOpacity: DOT_OPACITY,
+        color: "transparent",
+        weight: 0,
+      }).addTo(map);
+
+      const popupHtml = renderToString(<ReportPopup report={report} />);
+      marker.bindPopup(popupHtml, { maxWidth: 200 });
+
+      markersRef.current.push(marker);
+    });
+
+    return () => {
+      markersRef.current.forEach((m) => m.remove());
+      markersRef.current = [];
+    };
+  }, [map, visibleReports]);
+
+  return null;
+};

--- a/apps/web/components/maps/map-filters.tsx
+++ b/apps/web/components/maps/map-filters.tsx
@@ -16,6 +16,10 @@ interface MapFiltersProps {
 
 const ALL_CATEGORIES: ReportCategory[] = ["berlubang", "retak", "lainnya"];
 
+/**
+ * Category and date-range filter bar rendered above the map.
+ * Calls onChange whenever the user toggles a category or adjusts a date input.
+ */
 export const MapFilters = ({ filters, onChange }: MapFiltersProps) => {
   const handleCategoryToggle = (category: ReportCategory) => {
     const next = filters.categories.includes(category)

--- a/apps/web/components/maps/map-filters.tsx
+++ b/apps/web/components/maps/map-filters.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { REPORT_CATEGORIES } from "../../constant/reports";
+import type { ReportCategory } from "../../lib/maps/constants";
+
+export interface MapFiltersState {
+  categories: ReportCategory[];
+  dateFrom: string;
+  dateTo: string;
+}
+
+interface MapFiltersProps {
+  filters: MapFiltersState;
+  onChange: (filters: MapFiltersState) => void;
+}
+
+const ALL_CATEGORIES: ReportCategory[] = ["berlubang", "retak", "lainnya"];
+
+export const MapFilters = ({ filters, onChange }: MapFiltersProps) => {
+  const handleCategoryToggle = (category: ReportCategory) => {
+    const next = filters.categories.includes(category)
+      ? filters.categories.filter((c) => c !== category)
+      : [...filters.categories, category];
+    onChange({ ...filters, categories: next });
+  };
+
+  const handleReset = () => {
+    onChange({ categories: ALL_CATEGORIES, dateFrom: "", dateTo: "" });
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 border-b border-neutral-200 bg-white px-4 py-2 shadow-sm">
+      <span className="text-xs font-semibold tracking-wide text-neutral-600 uppercase">
+        Filter:
+      </span>
+
+      {/* Category checkboxes */}
+      <div className="flex flex-wrap gap-2">
+        {ALL_CATEGORIES.map((category) => {
+          const meta = REPORT_CATEGORIES[category];
+          const checked = filters.categories.includes(category);
+          return (
+            <label
+              key={category}
+              className="flex cursor-pointer items-center gap-1.5 rounded-full border border-neutral-200 px-2.5 py-1 text-xs font-medium text-neutral-700 hover:bg-neutral-50 has-[:checked]:border-red-300 has-[:checked]:bg-red-50 has-[:checked]:text-red-700"
+            >
+              <input
+                type="checkbox"
+                className="sr-only"
+                checked={checked}
+                onChange={() => handleCategoryToggle(category)}
+              />
+              {meta.icon} {meta.label}
+            </label>
+          );
+        })}
+      </div>
+
+      {/* Date range */}
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs text-neutral-500">Dari:</span>
+        <input
+          type="date"
+          value={filters.dateFrom}
+          onChange={(e) => onChange({ ...filters, dateFrom: e.target.value })}
+          className="rounded border border-neutral-200 px-2 py-0.5 text-xs text-neutral-700 focus:ring-1 focus:ring-red-400 focus:outline-none"
+        />
+        <span className="text-xs text-neutral-500">Hingga:</span>
+        <input
+          type="date"
+          value={filters.dateTo}
+          onChange={(e) => onChange({ ...filters, dateTo: e.target.value })}
+          className="rounded border border-neutral-200 px-2 py-0.5 text-xs text-neutral-700 focus:ring-1 focus:ring-red-400 focus:outline-none"
+        />
+      </div>
+
+      {/* Reset */}
+      <button
+        onClick={handleReset}
+        className="ml-auto rounded border border-neutral-200 px-2.5 py-1 text-xs text-neutral-600 hover:bg-neutral-100"
+      >
+        Reset
+      </button>
+    </div>
+  );
+};

--- a/apps/web/components/maps/map-legend.tsx
+++ b/apps/web/components/maps/map-legend.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { CATEGORY_COLORS, type ReportCategory } from "../../lib/maps/constants";
+import { REPORT_CATEGORIES } from "../../constant/reports";
+
+const LEGEND_ENTRIES: ReportCategory[] = ["berlubang", "retak", "lainnya"];
+
+export const MapLegend = () => {
+  return (
+    <div className="absolute bottom-8 left-2 z-[1000] rounded-lg border border-neutral-200 bg-white/90 px-3 py-2 shadow-md backdrop-blur-sm">
+      <p className="mb-1.5 text-xs font-semibold text-neutral-700">Kategori</p>
+      <ul className="space-y-1">
+        {LEGEND_ENTRIES.map((category) => {
+          const meta = REPORT_CATEGORIES[category];
+          return (
+            <li key={category} className="flex items-center gap-2">
+              <span
+                className="inline-block h-3 w-3 flex-shrink-0 rounded-full"
+                style={{ backgroundColor: CATEGORY_COLORS[category] }}
+              />
+              <span className="text-xs text-neutral-600">
+                {meta.icon} {meta.label}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};

--- a/apps/web/components/maps/map-legend.tsx
+++ b/apps/web/components/maps/map-legend.tsx
@@ -5,6 +5,10 @@ import { REPORT_CATEGORIES } from "../../constant/reports";
 
 const LEGEND_ENTRIES: ReportCategory[] = ["berlubang", "retak", "lainnya"];
 
+/**
+ * Overlaid legend showing the color coding for each report category.
+ * Positioned in the bottom-left corner of the map.
+ */
 export const MapLegend = () => {
   return (
     <div className="absolute bottom-8 left-2 z-[1000] rounded-lg border border-neutral-200 bg-white/90 px-3 py-2 shadow-md backdrop-blur-sm">

--- a/apps/web/components/maps/report-popup.tsx
+++ b/apps/web/components/maps/report-popup.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { REPORT_CATEGORIES } from "../../constant/reports";
+import type { MapReport, ReportCategory } from "../../lib/maps/constants";
+
+interface ReportPopupProps {
+  report: MapReport;
+}
+
+const formatDate = (dateString: string): string => {
+  return new Date(dateString).toLocaleDateString("id-ID", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+};
+
+export const ReportPopup = ({ report }: ReportPopupProps) => {
+  const category = REPORT_CATEGORIES[report.category as ReportCategory];
+
+  return (
+    <div className="w-48">
+      {report.image_url && (
+        <div className="relative mb-2 h-[75px] w-full overflow-hidden rounded">
+          <Image
+            src={report.image_url}
+            alt={`Laporan kerusakan ${category?.label ?? report.category}`}
+            width={192}
+            height={75}
+            className="h-full w-full object-cover"
+            unoptimized
+          />
+        </div>
+      )}
+      <div className="mb-1">
+        <span
+          className={`rounded px-1.5 py-0.5 text-xs font-medium ${category?.color ?? "bg-neutral-100 text-neutral-700"}`}
+        >
+          {category?.icon} {category?.label ?? report.category}
+        </span>
+      </div>
+      <p className="mb-1 text-xs leading-snug text-neutral-700">
+        {report.street_name}
+      </p>
+      <p className="mb-2 text-xs text-neutral-500">
+        {formatDate(report.created_at)}
+      </p>
+      <Link
+        href={`/laporan/${report.id}`}
+        className="block rounded bg-red-600 px-2 py-1 text-center text-xs font-medium text-white hover:bg-red-700"
+      >
+        Lihat laporan
+      </Link>
+    </div>
+  );
+};

--- a/apps/web/components/maps/report-popup.tsx
+++ b/apps/web/components/maps/report-popup.tsx
@@ -17,6 +17,10 @@ const formatDate = (dateString: string): string => {
   });
 };
 
+/**
+ * Popup card shown when a map marker is clicked.
+ * Rendered to an HTML string via renderToString for use with Leaflet's bindPopup.
+ */
 export const ReportPopup = ({ report }: ReportPopupProps) => {
   const category = REPORT_CATEGORIES[report.category as ReportCategory];
 

--- a/apps/web/components/maps/reports-map.tsx
+++ b/apps/web/components/maps/reports-map.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import "leaflet/dist/leaflet.css";
+import { useState, useMemo } from "react";
+import { MapContainer, TileLayer } from "react-leaflet";
+import {
+  DEFAULT_CENTER,
+  DEFAULT_ZOOM,
+  type MapReport,
+  type ReportCategory,
+} from "../../lib/maps/constants";
+import { DensityDotsLayer } from "./density-dots-layer";
+import { MapFilters, type MapFiltersState } from "./map-filters";
+import { MapLegend } from "./map-legend";
+
+interface ReportsMapProps {
+  reports: MapReport[];
+}
+
+const applyFilters = (
+  reports: MapReport[],
+  filters: MapFiltersState,
+): MapReport[] => {
+  return reports.filter((report) => {
+    if (!filters.categories.includes(report.category as ReportCategory))
+      return false;
+    if (filters.dateFrom) {
+      const reportDate = new Date(report.created_at);
+      const fromDate = new Date(filters.dateFrom);
+      if (reportDate < fromDate) return false;
+    }
+    if (filters.dateTo) {
+      const reportDate = new Date(report.created_at);
+      const toDate = new Date(filters.dateTo);
+      // Include the entire "to" day
+      toDate.setHours(23, 59, 59, 999);
+      if (reportDate > toDate) return false;
+    }
+    return true;
+  });
+};
+
+const ReportsMap = ({ reports }: ReportsMapProps) => {
+  const [filters, setFilters] = useState<MapFiltersState>({
+    categories: ["berlubang", "retak", "lainnya"],
+    dateFrom: "",
+    dateTo: "",
+  });
+
+  const filteredReports = useMemo(
+    () => applyFilters(reports, filters),
+    [reports, filters],
+  );
+
+  return (
+    <div className="flex flex-col" style={{ height: "calc(100vh - 64px)" }}>
+      <MapFilters filters={filters} onChange={setFilters} />
+      <div className="relative flex-1">
+        <MapContainer
+          center={DEFAULT_CENTER}
+          zoom={DEFAULT_ZOOM}
+          style={{ height: "100%", width: "100%" }}
+          className="z-0"
+        >
+          <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+          <DensityDotsLayer reports={filteredReports} />
+        </MapContainer>
+        <MapLegend />
+      </div>
+    </div>
+  );
+};
+
+export default ReportsMap;

--- a/apps/web/components/maps/reports-map.tsx
+++ b/apps/web/components/maps/reports-map.tsx
@@ -40,6 +40,10 @@ const applyFilters = (
   });
 };
 
+/**
+ * Full-page interactive Leaflet map displaying filtered road damage reports.
+ * Composes MapFilters, DensityDotsLayer, and MapLegend into a single view.
+ */
 const ReportsMap = ({ reports }: ReportsMapProps) => {
   const [filters, setFilters] = useState<MapFiltersState>({
     categories: ["berlubang", "retak", "lainnya"],

--- a/apps/web/components/sharing/share-dialog.tsx
+++ b/apps/web/components/sharing/share-dialog.tsx
@@ -23,6 +23,7 @@ import {
   SharingPreview,
   SharingActions,
 } from "./index";
+import type { GenerateAICaptionRequest } from "@/services/api-client";
 
 interface ShareDialogProps {
   isOpen: boolean;
@@ -62,7 +63,7 @@ export function ShareDialog({
     const result = await generateAICaption(
       reportId,
       platform,
-      tone as "formal" | "urgent" | "community" | "informative",
+      tone as GenerateAICaptionRequest["tone"],
       true,
     );
 

--- a/apps/web/lib/maps/constants.ts
+++ b/apps/web/lib/maps/constants.ts
@@ -1,0 +1,23 @@
+export type ReportCategory = "berlubang" | "retak" | "lainnya";
+
+export interface MapReport {
+  id: string;
+  lat: number;
+  lon: number;
+  category: ReportCategory;
+  street_name: string;
+  image_url: string;
+  created_at: string;
+}
+
+export const CATEGORY_COLORS: Record<ReportCategory, string> = {
+  berlubang: "#ef4444",
+  retak: "#f97316",
+  lainnya: "#eab308",
+};
+
+export const DOT_RADIUS = 8;
+export const DOT_OPACITY = 0.3;
+
+export const DEFAULT_CENTER: [number, number] = [-2.5, 118.0];
+export const DEFAULT_ZOOM = 5;

--- a/apps/web/lib/maps/viewport-filter.ts
+++ b/apps/web/lib/maps/viewport-filter.ts
@@ -2,7 +2,8 @@ import type { LatLngBounds } from "leaflet";
 import type { MapReport } from "./constants";
 
 /**
- * Filters reports to only those within the given Leaflet LatLngBounds.
+ * Filters reports to those within the given Leaflet map bounds.
+ * Used by DensityDotsLayer for viewport culling on pan/zoom.
  */
 export const filterReportsInBounds = (
   reports: MapReport[],

--- a/apps/web/lib/maps/viewport-filter.ts
+++ b/apps/web/lib/maps/viewport-filter.ts
@@ -1,0 +1,12 @@
+import type { LatLngBounds } from "leaflet";
+import type { MapReport } from "./constants";
+
+/**
+ * Filters reports to only those within the given Leaflet LatLngBounds.
+ */
+export const filterReportsInBounds = (
+  reports: MapReport[],
+  bounds: LatLngBounds,
+): MapReport[] => {
+  return reports.filter((report) => bounds.contains([report.lat, report.lon]));
+};


### PR DESCRIPTION
## Summary

- Implements `/peta` page — visualizes all verified road damage reports as semi-transparent circle dots on a Leaflet map
- Density emerges naturally from overlapping dots (~30% opacity) — no computed heatmap needed
- 5 geographic hotspot clusters in Bekasi (Harapan Indah, Bekasi Timur, Bekasi Utara, Cikarang, Summarecon) will be clearly visible once the seed data PR (#32) is merged
- Adds "Peta" entry to main navigation (desktop) between "Laporan" and "Cara Kerja"

**Supersedes #12, #13, #14** (per issue #30 spec)

## What's included

- `app/peta/page.tsx` — server component, fetches up to 1000 reports, filters null lat/lon
- `app/peta/map-client-wrapper.tsx` — `next/dynamic` boundary with `ssr: false` (Leaflet requires window)
- `components/maps/reports-map.tsx` — main map container, holds filter state
- `components/maps/density-dots-layer.tsx` — renders `L.circleMarker` instances, viewport culling on `moveend`
- `components/maps/report-popup.tsx` — thumbnail + category badge + street + date + link to `/laporan/[id]`
- `components/maps/map-filters.tsx` — category checkboxes (all pre-checked) + date range + reset
- `components/maps/map-legend.tsx` — color legend overlay bottom-left
- `lib/maps/constants.ts` — `MapReport` type, `CATEGORY_COLORS`, dot constants, default center
- `lib/maps/viewport-filter.ts` — pure `filterReportsInBounds(reports, LatLngBounds)`

## Design decisions

- Dot: radius 8px, opacity 30%, no stroke — overlapping dots create visible density
- Colors: berlubang `#ef4444`, retak `#f97316`, lainnya `#eab308`
- Default view: Indonesia at zoom 5 (center `[-2.5, 118.0]`)
- Popup uses `renderToString` for Leaflet compatibility — link to report detail works (full-page nav, not SPA)
- Leaflet CSS imported in client component only, not global layout

## Test plan

- [ ] Visit `/peta` — map renders centered on Indonesia at zoom 5
- [ ] Dots appear at ~30% opacity; overlapping dots visibly darker
- [ ] Pan/zoom — only visible-bounds dots remain in DOM (check `.leaflet-interactive` count in DevTools)
- [ ] Toggle each category checkbox — that category's dots disappear immediately
- [ ] Set date range — dots outside range hidden
- [ ] Reset button — all filters cleared, all dots restored
- [ ] Click a dot — popup shows thumbnail, category, street, date, "Lihat laporan" link
- [ ] "Lihat laporan" link navigates to correct `/laporan/[id]` page
- [ ] "Peta" appears in nav between "Laporan" and "Cara Kerja"
- [ ] `bun run check-types && bun run lint` — no errors

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)