### PR TITLE
feat: add shareable map views and dashboard map (#15, #16)

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -13,16 +13,25 @@ import {
   AvatarImage,
 } from "@repo/ui/components/ui/avatar";
 import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@repo/ui/components/ui/tabs";
+import {
   FileText,
   Plus,
   MapPin,
   Calendar,
   TrendingUp,
   Eye,
+  List,
+  Map,
 } from "lucide-react";
 import Link from "next/link";
 import Header from "../../components/layout/header";
 import { ReportsTable } from "../../components/dashboard/reports-table";
+import { DashboardMapWrapper } from "../../components/dashboard/dashboard-map-wrapper";
 import {
   requireAuth,
   getUserStats,
@@ -30,6 +39,10 @@ import {
 } from "../../lib/auth-server";
 import { getUserReportsAction } from "../../lib/auth-actions";
 import type { ReportWithUser } from "../../lib/types/api";
+import type {
+  DashboardMapReport,
+  ReportStatus,
+} from "../../lib/maps/constants";
 
 type DashboardReport = {
   id: string;
@@ -47,22 +60,39 @@ export default async function DashboardPage() {
 
   // Server-side data fetching
   let userReports: DashboardReport[] = [];
+  let mapReports: DashboardMapReport[] = [];
   let stats: UserStatsResponse | null = null;
 
   try {
-    // Fetch user reports with limit for dashboard
-    const searchParams = new URLSearchParams("limit=6");
-    const reportsData = await getUserReportsAction(searchParams);
+    // Fetch all user reports (map needs all, table shows recent 6)
+    const allParams = new URLSearchParams("limit=1000");
+    const allReportsData = await getUserReportsAction(allParams);
+    const allItems: ReportWithUser[] = allReportsData?.items || [];
 
-    // Transform API data to match ReportsTable expected format
-    userReports = (reportsData?.items || []).map((report: ReportWithUser) => ({
+    // Transform for table (recent 6)
+    userReports = allItems.slice(0, 6).map((report) => ({
       ...report,
-      title: report.street_name, // Use street_name as title
-      status: report.status || "pending", // Use actual status from API
+      title: report.street_name,
+      status: report.status || "pending",
     }));
+
+    // Filter for map (only reports with valid coordinates)
+    mapReports = allItems
+      .filter((r) => r.lat !== null && r.lon !== null)
+      .map((r) => ({
+        id: r.id,
+        lat: r.lat,
+        lon: r.lon,
+        category: r.category,
+        street_name: r.street_name,
+        image_url: r.image_url,
+        created_at: r.created_at,
+        status: (r.status || "pending") as ReportStatus,
+      }));
   } catch (error) {
     console.error("Error fetching user reports:", error);
-    userReports = []; // Fallback to empty array
+    userReports = [];
+    mapReports = [];
   }
 
   try {
@@ -70,7 +100,7 @@ export default async function DashboardPage() {
     stats = await getUserStats();
   } catch (error) {
     console.error("Error fetching user stats:", error);
-    stats = null; // Fallback to null
+    stats = null;
   }
 
   return (
@@ -237,13 +267,13 @@ export default async function DashboardPage() {
           </Card>
         </div>
 
-        {/* Recent Reports Section */}
+        {/* Reports Section with Tabs */}
         <Card className="border-0 shadow-lg" id="my-reports">
           <CardHeader className="px-8 py-6">
             <div className="flex items-center justify-between">
               <div>
                 <CardTitle className="text-2xl font-bold text-neutral-900">
-                  Laporan Terbaru Saya
+                  Laporan Saya
                 </CardTitle>
                 <CardDescription className="mt-2 text-lg text-neutral-600">
                   Kelola dan pantau status laporan yang telah Anda buat
@@ -259,17 +289,36 @@ export default async function DashboardPage() {
             </div>
           </CardHeader>
           <CardContent className="px-8 pb-8">
-            {userReports.length > 0 ? (
-              <ReportsTable data={userReports} />
-            ) : (
-              <div className="py-12 text-center">
-                <FileText className="mx-auto mb-4 h-12 w-12 text-neutral-400" />
-                <p className="mb-4 text-neutral-600">Belum ada laporan</p>
-                <Button asChild>
-                  <Link href="/laporan/buat">Buat Laporan Pertama</Link>
-                </Button>
-              </div>
-            )}
+            <Tabs defaultValue="daftar">
+              <TabsList className="mb-6">
+                <TabsTrigger value="daftar" className="gap-1.5">
+                  <List className="h-4 w-4" />
+                  Daftar
+                </TabsTrigger>
+                <TabsTrigger value="peta" className="gap-1.5">
+                  <Map className="h-4 w-4" />
+                  Peta
+                </TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="daftar">
+                {userReports.length > 0 ? (
+                  <ReportsTable data={userReports} />
+                ) : (
+                  <div className="py-12 text-center">
+                    <FileText className="mx-auto mb-4 h-12 w-12 text-neutral-400" />
+                    <p className="mb-4 text-neutral-600">Belum ada laporan</p>
+                    <Button asChild>
+                      <Link href="/laporan/buat">Buat Laporan Pertama</Link>
+                    </Button>
+                  </div>
+                )}
+              </TabsContent>
+
+              <TabsContent value="peta">
+                <DashboardMapWrapper reports={mapReports} />
+              </TabsContent>
+            </Tabs>
           </CardContent>
         </Card>
       </main>

--- a/apps/web/app/peta/map-client-wrapper.tsx
+++ b/apps/web/app/peta/map-client-wrapper.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 import type { MapReport } from "../../lib/maps/constants";
+import type { MapUrlState } from "../../lib/maps/url-state";
 import PetaLoading from "./loading";
 
 const ReportsMap = dynamic(() => import("../../components/maps/reports-map"), {
@@ -11,12 +12,16 @@ const ReportsMap = dynamic(() => import("../../components/maps/reports-map"), {
 
 interface MapClientWrapperProps {
   reports: MapReport[];
+  initialState?: MapUrlState;
 }
 
 /**
  * Client-side wrapper that dynamically loads ReportsMap with SSR disabled.
- * Receives pre-fetched reports from the server component and passes them to the map.
+ * Receives pre-fetched reports and optional initial map state from the server component.
  */
-export const MapClientWrapper = ({ reports }: MapClientWrapperProps) => {
-  return <ReportsMap reports={reports} />;
+export const MapClientWrapper = ({
+  reports,
+  initialState,
+}: MapClientWrapperProps) => {
+  return <ReportsMap reports={reports} initialState={initialState} />;
 };

--- a/apps/web/app/peta/page.tsx
+++ b/apps/web/app/peta/page.tsx
@@ -1,6 +1,7 @@
 import Header from "components/layout/header";
 import { MapClientWrapper } from "./map-client-wrapper";
 import type { MapReport } from "../../lib/maps/constants";
+import { parseMapStateFromParams } from "../../lib/maps/url-state";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
 
@@ -56,14 +57,24 @@ const fetchMapReports = async (): Promise<MapReport[]> => {
   }
 };
 
-export default async function PetaPage() {
+interface PetaPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function PetaPage({ searchParams }: PetaPageProps) {
+  const params = await searchParams;
+  const urlParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (typeof value === "string") urlParams.set(key, value);
+  }
+  const initialState = parseMapStateFromParams(urlParams);
   const reports = await fetchMapReports();
 
   return (
     <div className="min-h-screen bg-neutral-50">
       <Header />
       <main>
-        <MapClientWrapper reports={reports} />
+        <MapClientWrapper reports={reports} initialState={initialState} />
       </main>
     </div>
   );

--- a/apps/web/components/dashboard/dashboard-map-wrapper.tsx
+++ b/apps/web/components/dashboard/dashboard-map-wrapper.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { DashboardMapReport } from "../../lib/maps/constants";
+
+const DashboardMap = dynamic(() => import("./dashboard-map"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-[400px] items-center justify-center rounded-lg bg-neutral-100">
+      <div className="text-center">
+        <div className="mx-auto mb-3 h-8 w-8 animate-spin rounded-full border-4 border-neutral-300 border-t-neutral-900" />
+        <p className="text-sm text-neutral-500">Memuat peta...</p>
+      </div>
+    </div>
+  ),
+});
+
+interface DashboardMapWrapperProps {
+  reports: DashboardMapReport[];
+}
+
+/**
+ * Client-side wrapper that dynamically imports DashboardMap with SSR disabled.
+ * Shows a loading spinner while Leaflet is being loaded.
+ */
+export const DashboardMapWrapper = ({ reports }: DashboardMapWrapperProps) => {
+  return <DashboardMap reports={reports} />;
+};

--- a/apps/web/components/dashboard/dashboard-map.tsx
+++ b/apps/web/components/dashboard/dashboard-map.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import "leaflet/dist/leaflet.css";
+import { useEffect, useRef } from "react";
+import { MapContainer, TileLayer, useMap } from "react-leaflet";
+import L from "leaflet";
+import type { CircleMarker as LeafletCircleMarker } from "leaflet";
+import { renderToString } from "react-dom/server";
+import {
+  BEKASI_CENTER,
+  BEKASI_ZOOM,
+  STATUS_COLORS,
+  type DashboardMapReport,
+} from "../../lib/maps/constants";
+import { MapPin } from "lucide-react";
+
+interface DashboardMapProps {
+  reports: DashboardMapReport[];
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  pending: "Menunggu",
+  verified: "Terverifikasi",
+  rejected: "Ditolak",
+};
+
+/**
+ * Popup content for a dashboard map marker. Shows thumbnail, street name,
+ * status badge, date, and action links.
+ */
+const DashboardPopup = ({ report }: { report: DashboardMapReport }) => {
+  const statusColor = STATUS_COLORS[report.status] ?? "#6b7280";
+  const statusLabel = STATUS_LABELS[report.status] ?? report.status;
+
+  return (
+    <div className="w-48">
+      {report.image_url && (
+        // eslint-disable-next-line @next/next/no-img-element -- rendered via renderToString for Leaflet popup, outside React tree
+        <img
+          src={report.image_url}
+          alt={report.street_name}
+          className="mb-2 h-24 w-full rounded object-cover"
+        />
+      )}
+      <p className="mb-1 text-sm font-semibold">{report.street_name}</p>
+      <span
+        className="mb-1 inline-block rounded-full px-2 py-0.5 text-xs font-medium text-white"
+        style={{ backgroundColor: statusColor }}
+      >
+        {statusLabel}
+      </span>
+      <p className="mb-2 text-xs text-neutral-500">
+        {new Date(report.created_at).toLocaleDateString("id-ID", {
+          day: "numeric",
+          month: "short",
+          year: "numeric",
+        })}
+      </p>
+      <div className="flex gap-2">
+        <a
+          href={`/laporan/${report.id}`}
+          className="text-xs font-medium text-blue-600 hover:underline"
+        >
+          Lihat Detail
+        </a>
+        <a
+          href={`/laporan/${report.id}/edit`}
+          className="text-xs font-medium text-neutral-600 hover:underline"
+        >
+          Edit
+        </a>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Renders markers and auto-fits bounds to the user's reports on mount.
+ */
+const DashboardMarkersLayer = ({
+  reports,
+}: {
+  reports: DashboardMapReport[];
+}) => {
+  const map = useMap();
+  const markersRef = useRef<LeafletCircleMarker[]>([]);
+
+  // Auto-fit bounds on mount
+  useEffect(() => {
+    if (reports.length === 0) return;
+    const bounds = L.latLngBounds(reports.map((r) => [r.lat, r.lon]));
+    map.fitBounds(bounds, { padding: [40, 40], maxZoom: 15 });
+  }, [map, reports]);
+
+  // Render markers
+  useEffect(() => {
+    markersRef.current.forEach((m) => m.remove());
+    markersRef.current = [];
+
+    reports.forEach((report) => {
+      const color = STATUS_COLORS[report.status] ?? "#6b7280";
+      const marker = L.circleMarker([report.lat, report.lon], {
+        radius: 10,
+        fillColor: color,
+        fillOpacity: 1,
+        color: "#fff",
+        weight: 2,
+      }).addTo(map);
+
+      const popupHtml = renderToString(<DashboardPopup report={report} />);
+      marker.bindPopup(popupHtml, { maxWidth: 220 });
+
+      markersRef.current.push(marker);
+    });
+
+    return () => {
+      markersRef.current.forEach((m) => m.remove());
+      markersRef.current = [];
+    };
+  }, [map, reports]);
+
+  return null;
+};
+
+/**
+ * Interactive Leaflet map showing the current user's reports with status-based
+ * marker colors. Auto-fits to report bounds on mount.
+ */
+const DashboardMap = ({ reports }: DashboardMapProps) => {
+  if (reports.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center">
+        <MapPin className="mb-4 h-12 w-12 text-neutral-400" />
+        <p className="mb-2 text-neutral-600">Belum ada laporan dengan lokasi</p>
+        <p className="text-sm text-neutral-500">
+          Laporan yang memiliki koordinat akan ditampilkan di peta ini
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg" style={{ height: "400px" }}>
+      <MapContainer
+        center={BEKASI_CENTER}
+        zoom={BEKASI_ZOOM}
+        style={{ height: "100%", width: "100%" }}
+        className="z-0"
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        <DashboardMarkersLayer reports={reports} />
+      </MapContainer>
+    </div>
+  );
+};
+
+export default DashboardMap;

--- a/apps/web/components/maps/reports-map.tsx
+++ b/apps/web/components/maps/reports-map.tsx
@@ -1,20 +1,23 @@
 "use client";
 
 import "leaflet/dist/leaflet.css";
-import { useState, useMemo } from "react";
-import { MapContainer, TileLayer } from "react-leaflet";
+import { useState, useMemo, useCallback, useEffect } from "react";
+import { MapContainer, TileLayer, useMap } from "react-leaflet";
 import {
   DEFAULT_CENTER,
   DEFAULT_ZOOM,
   type MapReport,
   type ReportCategory,
 } from "../../lib/maps/constants";
+import { serializeMapState, type MapUrlState } from "../../lib/maps/url-state";
 import { DensityDotsLayer } from "./density-dots-layer";
 import { MapFilters, type MapFiltersState } from "./map-filters";
 import { MapLegend } from "./map-legend";
+import { ShareMapButton } from "./share-map-button";
 
 interface ReportsMapProps {
   reports: MapReport[];
+  initialState?: MapUrlState;
 }
 
 const applyFilters = (
@@ -32,7 +35,6 @@ const applyFilters = (
     if (filters.dateTo) {
       const reportDate = new Date(report.created_at);
       const toDate = new Date(filters.dateTo);
-      // Include the entire "to" day
       toDate.setHours(23, 59, 59, 999);
       if (reportDate > toDate) return false;
     }
@@ -41,28 +43,84 @@ const applyFilters = (
 };
 
 /**
- * Full-page interactive Leaflet map displaying filtered road damage reports.
- * Composes MapFilters, DensityDotsLayer, and MapLegend into a single view.
+ * Inner component that syncs map position changes back to the URL
+ * via replaceState (no server re-fetch).
  */
-const ReportsMap = ({ reports }: ReportsMapProps) => {
+const MapUrlSync = ({ filters }: { filters: MapFiltersState }) => {
+  const map = useMap();
+
+  useEffect(() => {
+    const syncUrl = () => {
+      const center = map.getCenter();
+      const zoom = map.getZoom();
+      const qs = serializeMapState({
+        categories: filters.categories,
+        dateFrom: filters.dateFrom,
+        dateTo: filters.dateTo,
+        lat: center.lat,
+        lng: center.lng,
+        zoom,
+      });
+      window.history.replaceState(null, "", `/peta${qs}`);
+    };
+
+    map.on("moveend", syncUrl);
+    return () => {
+      map.off("moveend", syncUrl);
+    };
+  }, [map, filters]);
+
+  // Also sync when filters change (without map movement)
+  useEffect(() => {
+    const center = map.getCenter();
+    const zoom = map.getZoom();
+    const qs = serializeMapState({
+      categories: filters.categories,
+      dateFrom: filters.dateFrom,
+      dateTo: filters.dateTo,
+      lat: center.lat,
+      lng: center.lng,
+      zoom,
+    });
+    window.history.replaceState(null, "", `/peta${qs}`);
+  }, [map, filters]);
+
+  return null;
+};
+
+/**
+ * Full-page interactive Leaflet map displaying filtered road damage reports.
+ * Composes MapFilters, DensityDotsLayer, MapLegend, and ShareMapButton.
+ * Optionally restores map state from URL search params via initialState.
+ */
+const ReportsMap = ({ reports, initialState }: ReportsMapProps) => {
   const [filters, setFilters] = useState<MapFiltersState>({
-    categories: ["berlubang", "retak", "lainnya"],
-    dateFrom: "",
-    dateTo: "",
+    categories: initialState?.categories ?? ["berlubang", "retak", "lainnya"],
+    dateFrom: initialState?.dateFrom ?? "",
+    dateTo: initialState?.dateTo ?? "",
   });
+
+  const center: [number, number] = initialState
+    ? [initialState.lat, initialState.lng]
+    : DEFAULT_CENTER;
+  const zoom = initialState?.zoom ?? DEFAULT_ZOOM;
 
   const filteredReports = useMemo(
     () => applyFilters(reports, filters),
     [reports, filters],
   );
 
+  const handleFiltersChange = useCallback((next: MapFiltersState) => {
+    setFilters(next);
+  }, []);
+
   return (
     <div className="flex flex-col" style={{ height: "calc(100vh - 64px)" }}>
-      <MapFilters filters={filters} onChange={setFilters} />
+      <MapFilters filters={filters} onChange={handleFiltersChange} />
       <div className="relative flex-1">
         <MapContainer
-          center={DEFAULT_CENTER}
-          zoom={DEFAULT_ZOOM}
+          center={center}
+          zoom={zoom}
           style={{ height: "100%", width: "100%" }}
           className="z-0"
         >
@@ -71,8 +129,10 @@ const ReportsMap = ({ reports }: ReportsMapProps) => {
             url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           />
           <DensityDotsLayer reports={filteredReports} />
+          <MapUrlSync filters={filters} />
         </MapContainer>
         <MapLegend />
+        <ShareMapButton />
       </div>
     </div>
   );

--- a/apps/web/components/maps/share-map-button.tsx
+++ b/apps/web/components/maps/share-map-button.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import { Share2, Copy, Check } from "lucide-react";
+import { toast } from "sonner";
+
+/**
+ * Floating share button on the map that copies the current URL (which includes
+ * map state as search params) to the clipboard, with WhatsApp/Twitter share options.
+ */
+export const ShareMapButton = () => {
+  const [copied, setCopied] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      toast.success("Link disalin!");
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error("Gagal menyalin link");
+    }
+  };
+
+  const handleShareWhatsApp = () => {
+    const url = encodeURIComponent(window.location.href);
+    const text = encodeURIComponent("Lihat peta kerusakan jalan di Viralkan:");
+    window.open(`https://wa.me/?text=${text}%20${url}`, "_blank");
+    setOpen(false);
+  };
+
+  const handleShareTwitter = () => {
+    const url = encodeURIComponent(window.location.href);
+    const text = encodeURIComponent("Lihat peta kerusakan jalan di Viralkan");
+    window.open(
+      `https://twitter.com/intent/tweet?text=${text}&url=${url}`,
+      "_blank",
+    );
+    setOpen(false);
+  };
+
+  return (
+    <div className="absolute top-3 right-3 z-[1000]">
+      <div className="relative">
+        <button
+          onClick={() => setOpen(!open)}
+          className="flex h-10 w-10 items-center justify-center rounded-lg border border-neutral-200 bg-white shadow-md transition-colors hover:bg-neutral-50"
+          title="Bagikan peta"
+          aria-label="Bagikan peta"
+        >
+          <Share2 className="h-4 w-4 text-neutral-700" />
+        </button>
+
+        {open && (
+          <div className="absolute top-12 right-0 w-44 rounded-lg border border-neutral-200 bg-white py-1 shadow-lg">
+            <button
+              onClick={handleCopy}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-neutral-700 hover:bg-neutral-50"
+            >
+              {copied ? (
+                <Check className="h-4 w-4 text-green-600" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+              {copied ? "Disalin!" : "Salin Link"}
+            </button>
+            <button
+              onClick={handleShareWhatsApp}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-neutral-700 hover:bg-neutral-50"
+            >
+              <span className="text-base">💬</span>
+              WhatsApp
+            </button>
+            <button
+              onClick={handleShareTwitter}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-neutral-700 hover:bg-neutral-50"
+            >
+              <span className="text-base">🐦</span>
+              Twitter
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/web/components/sharing/share-dialog.tsx
+++ b/apps/web/components/sharing/share-dialog.tsx
@@ -24,7 +24,6 @@ import {
   SharingPreview,
   SharingActions,
 } from "./index";
-import type { GenerateAICaptionRequest } from "@/services/api-client";
 
 interface ShareDialogProps {
   isOpen: boolean;

--- a/apps/web/lib/maps/constants.ts
+++ b/apps/web/lib/maps/constants.ts
@@ -21,3 +21,20 @@ export const DOT_OPACITY = 0.3;
 
 export const DEFAULT_CENTER: [number, number] = [-2.5, 118.0];
 export const DEFAULT_ZOOM = 5;
+
+/** Bekasi center — used as fallback when user has no geolocated reports. */
+export const BEKASI_CENTER: [number, number] = [-6.2416, 107.0003];
+export const BEKASI_ZOOM = 12;
+
+export type ReportStatus = "pending" | "verified" | "rejected" | "deleted";
+
+export const STATUS_COLORS: Record<ReportStatus, string> = {
+  pending: "#6b7280",
+  verified: "#22c55e",
+  rejected: "#ef4444",
+  deleted: "#9ca3af",
+};
+
+export interface DashboardMapReport extends MapReport {
+  status: ReportStatus;
+}

--- a/apps/web/lib/maps/url-state.ts
+++ b/apps/web/lib/maps/url-state.ts
@@ -1,0 +1,92 @@
+import { DEFAULT_CENTER, DEFAULT_ZOOM, type ReportCategory } from "./constants";
+
+const ALL_CATEGORIES: ReportCategory[] = ["berlubang", "retak", "lainnya"];
+
+export interface MapUrlState {
+  categories: ReportCategory[];
+  dateFrom: string;
+  dateTo: string;
+  lat: number;
+  lng: number;
+  zoom: number;
+}
+
+/**
+ * Parse URL search params into a typed MapUrlState, falling back to defaults
+ * for missing or invalid values.
+ */
+export const parseMapStateFromParams = (
+  searchParams: URLSearchParams,
+): MapUrlState => {
+  const categoriesRaw = searchParams.get("categories");
+  const categories = categoriesRaw
+    ? (categoriesRaw
+        .split(",")
+        .filter((c) =>
+          ALL_CATEGORIES.includes(c as ReportCategory),
+        ) as ReportCategory[])
+    : ALL_CATEGORIES;
+
+  const lat = clampNumber(searchParams.get("lat"), -90, 90, DEFAULT_CENTER[0]);
+  const lng = clampNumber(
+    searchParams.get("lng"),
+    -180,
+    180,
+    DEFAULT_CENTER[1],
+  );
+  const zoom = clampNumber(searchParams.get("zoom"), 1, 18, DEFAULT_ZOOM);
+
+  return {
+    categories: categories.length > 0 ? categories : ALL_CATEGORIES,
+    dateFrom: searchParams.get("dateFrom") ?? "",
+    dateTo: searchParams.get("dateTo") ?? "",
+    lat,
+    lng,
+    zoom,
+  };
+};
+
+/**
+ * Serialize map state into a query string. Omits params that match defaults
+ * to keep URLs short.
+ */
+export const serializeMapState = (state: MapUrlState): string => {
+  const params = new URLSearchParams();
+
+  const isAllCategories =
+    state.categories.length === ALL_CATEGORIES.length &&
+    ALL_CATEGORIES.every((c) => state.categories.includes(c));
+  if (!isAllCategories) {
+    params.set("categories", state.categories.join(","));
+  }
+
+  if (state.dateFrom) params.set("dateFrom", state.dateFrom);
+  if (state.dateTo) params.set("dateTo", state.dateTo);
+
+  if (state.lat !== DEFAULT_CENTER[0]) {
+    params.set("lat", roundCoord(state.lat));
+  }
+  if (state.lng !== DEFAULT_CENTER[1]) {
+    params.set("lng", roundCoord(state.lng));
+  }
+  if (state.zoom !== DEFAULT_ZOOM) {
+    params.set("zoom", String(Math.round(state.zoom)));
+  }
+
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+};
+
+const clampNumber = (
+  raw: string | null,
+  min: number,
+  max: number,
+  fallback: number,
+): number => {
+  if (raw === null) return fallback;
+  const parsed = Number(raw);
+  if (Number.isNaN(parsed)) return fallback;
+  return Math.max(min, Math.min(max, parsed));
+};
+
+const roundCoord = (n: number): string => n.toFixed(4);


### PR DESCRIPTION
## Summary
- **Shareable Map Views (#16):** Map state (categories, date range, center, zoom) is now encoded in URL search params. Panning, zooming, or changing filters updates the URL via `replaceState`. A share button provides copy-link, WhatsApp, and Twitter sharing.
- **Dashboard Map (#15):** The dashboard's "Laporan Saya" section now has Daftar/Peta tabs. The Peta tab shows an interactive Leaflet map with the user's reports as status-colored markers (gray=pending, green=verified, red=rejected). Auto-fits to report bounds on load.
- **Bugfix:** Removed duplicate `GenerateAICaptionRequest` import in `ShareDialog` that caused build failure.

## Files changed
- `apps/web/lib/maps/url-state.ts` — new: parse/serialize map state to URL params
- `apps/web/lib/maps/constants.ts` — added `STATUS_COLORS`, `DashboardMapReport`, `BEKASI_CENTER`
- `apps/web/app/peta/page.tsx` — accepts `searchParams`, passes `initialState` to map
- `apps/web/app/peta/map-client-wrapper.tsx` — passes `initialState` through
- `apps/web/components/maps/reports-map.tsx` — initializes from URL state, syncs on changes, renders share button
- `apps/web/components/maps/share-map-button.tsx` — new: floating share button with dropdown
- `apps/web/components/dashboard/dashboard-map.tsx` — new: user reports map with status colors
- `apps/web/components/dashboard/dashboard-map-wrapper.tsx` — new: dynamic import wrapper
- `apps/web/app/dashboard/page.tsx` — added Tabs (Daftar/Peta), fetches all reports for map

## Test plan
- [ ] Open `/peta`, apply filters, pan/zoom → verify URL updates live
- [ ] Copy a `/peta?categories=berlubang&zoom=14&lat=-6.24&lng=107.00` URL → open in new tab → verify same view restores
- [ ] Click share button → verify "Salin Link" copies URL, WhatsApp/Twitter links open correct URLs
- [ ] Open `/dashboard` → verify Daftar tab shows table as before
- [ ] Switch to Peta tab → verify map loads with user's reports in status colors
- [ ] Click a marker → verify popup shows thumbnail, status badge, detail/edit links
- [ ] Test empty state (user with no geolocated reports) → verify friendly message
- [ ] Verify mobile responsiveness (filter bar wraps, tabs stack)

Closes #15, closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)