### PR TITLE
feat: admin activity log with filters and pagination

### DIFF
--- a/apps/api/src/routes/admin/api.ts
+++ b/apps/api/src/routes/admin/api.ts
@@ -17,6 +17,8 @@ import {
   AdminReportActionRequestSchema,
   AdminReportActionResponseSchema,
   AdminActionLogSchema,
+  AdminActivitiesQuerySchema,
+  PaginatedActivitiesResponseSchema,
 } from "./types";
 import {
   ShareAnalyticsQuerySchema,
@@ -793,6 +795,70 @@ const healthCheckRoute = createRoute({
   },
 });
 
+const getAdminActivitiesRoute = createRoute({
+  method: "get",
+  path: "/activities",
+  request: {
+    query: AdminActivitiesQuerySchema,
+  },
+  summary: "Get admin activity log",
+  description:
+    "Get paginated admin activity log with optional filters for action type, admin, and date range",
+  tags: ["Admin"],
+  security: [{ bearerAuth: [] }],
+  middleware: [requireAdmin],
+  responses: {
+    200: {
+      description: "Successfully retrieved admin activities",
+      content: {
+        "application/json": { schema: PaginatedActivitiesResponseSchema },
+      },
+    },
+    401: {
+      description: "User not authenticated",
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.object({
+              code: z.string(),
+              message: z.string(),
+              timestamp: z.string(),
+            }),
+          }),
+        },
+      },
+    },
+    403: {
+      description: "Admin access required",
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.object({
+              code: z.string(),
+              message: z.string(),
+              timestamp: z.string(),
+            }),
+          }),
+        },
+      },
+    },
+    500: {
+      description: "Internal server error",
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.object({
+              code: z.string(),
+              message: z.string(),
+              timestamp: z.string(),
+            }),
+          }),
+        },
+      },
+    },
+  },
+});
+
 // --- Route Handlers ---
 
 adminRouter.openapi(getAdminStatsRoute, async (c) => {
@@ -879,6 +945,55 @@ adminRouter.openapi(getAdminReportsRoute, async (c) => {
         error: {
           code: "INTERNAL_ERROR",
           message: "Failed to get admin reports",
+          timestamp: new Date().toISOString(),
+        },
+      },
+      500,
+    );
+  }
+});
+
+adminRouter.openapi(getAdminActivitiesRoute, async (c) => {
+  try {
+    const userId = c.get("user_id");
+
+    if (!userId) {
+      return c.json(
+        {
+          error: {
+            code: "UNAUTHORIZED",
+            message: "Authentication required",
+            timestamp: new Date().toISOString(),
+          },
+        },
+        401,
+      );
+    }
+
+    const queryData = c.req.valid("query");
+    const result = await adminShell.getAdminActivitiesShell(queryData);
+
+    if (result.success) {
+      return c.json(result.data, 200);
+    }
+
+    return c.json(
+      {
+        error: {
+          code: "FETCH_ERROR",
+          message: result.error || "Failed to get admin activities",
+          timestamp: new Date().toISOString(),
+        },
+      },
+      500,
+    );
+  } catch (error) {
+    console.error("Error getting admin activities:", error);
+    return c.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to get admin activities",
           timestamp: new Date().toISOString(),
         },
       },

--- a/apps/api/src/routes/admin/core.ts
+++ b/apps/api/src/routes/admin/core.ts
@@ -13,6 +13,7 @@ import type {
   ReportWithUser,
   AdminStatsResponse,
   AdminReportsResponse,
+  PaginatedActivitiesResponse,
 } from "./types";
 
 /**
@@ -107,6 +108,104 @@ export async function getAdminStats(
 
   return stats;
 }
+
+/**
+ * Get paginated admin activities with optional filters
+ */
+export const getAdminActivities = async (options: {
+  page?: number;
+  limit?: number;
+  action_type?: string;
+  admin_user_id?: string;
+  date_from?: string;
+  date_to?: string;
+}): Promise<PaginatedActivitiesResponse> => {
+  const {
+    page = 1,
+    limit = 20,
+    action_type,
+    admin_user_id,
+    date_from,
+    date_to,
+  } = options;
+  const offset = (page - 1) * limit;
+
+  // Build WHERE clause dynamically
+  let whereClause = "WHERE 1=1";
+  const params: any[] = [];
+
+  if (action_type) {
+    whereClause += ` AND aa.action_type = $${params.length + 1}`;
+    params.push(action_type);
+  }
+
+  if (admin_user_id) {
+    whereClause += ` AND aa.admin_user_id = $${params.length + 1}`;
+    params.push(admin_user_id);
+  }
+
+  if (date_from) {
+    whereClause += ` AND aa.created_at >= $${params.length + 1}::timestamptz`;
+    params.push(date_from);
+  }
+
+  if (date_to) {
+    whereClause += ` AND aa.created_at <= $${params.length + 1}::timestamptz`;
+    params.push(date_to);
+  }
+
+  // Get total count
+  const countQuery = `
+    SELECT COUNT(*) as total
+    FROM admin_actions aa
+    ${whereClause}
+  `;
+  const totalResult = await sql.unsafe(countQuery, params);
+  const total = parseInt(totalResult[0]?.total as string);
+
+  // Get activities with admin user name
+  const activitiesQuery = `
+    SELECT
+      aa.id,
+      aa.admin_user_id,
+      u.name as admin_user_name,
+      aa.action_type,
+      aa.target_type,
+      aa.target_id,
+      aa.details,
+      aa.created_at
+    FROM admin_actions aa
+    LEFT JOIN users u ON aa.admin_user_id = u.id
+    ${whereClause}
+    ORDER BY aa.created_at DESC
+    LIMIT $${params.length + 1} OFFSET $${params.length + 2}
+  `;
+
+  const activities = await sql.unsafe(activitiesQuery, [
+    ...params,
+    limit,
+    offset,
+  ]);
+
+  const items = activities.map((activity: any) => ({
+    id: activity.id,
+    admin_user_id: activity.admin_user_id,
+    admin_user_name: activity.admin_user_name || "Unknown",
+    action_type: activity.action_type,
+    target_type: activity.target_type,
+    target_id: activity.target_id,
+    details: activity.details,
+    created_at: activity.created_at.toISOString(),
+  }));
+
+  return {
+    items,
+    total,
+    page,
+    limit,
+    pages: Math.ceil(total / limit),
+  };
+};
 
 /**
  * Get reports for admin management

--- a/apps/api/src/routes/admin/shell.ts
+++ b/apps/api/src/routes/admin/shell.ts
@@ -11,8 +11,10 @@ import type {
   AdminReportsResponse,
   AdminReportActionRequest,
   AdminReportActionResponse,
+  PaginatedActivitiesResponse,
   ReportWithUser,
 } from "./types";
+import { getAdminActivities as getAdminActivitiesCore } from "./core";
 
 /**
  * Get admin statistics
@@ -233,6 +235,37 @@ export async function getAdminReports(
     };
   }
 }
+
+/**
+ * Get admin activities with pagination and filters
+ */
+export const getAdminActivitiesShell = async (
+  options: {
+    page?: number;
+    limit?: number;
+    action_type?: string;
+    admin_user_id?: string;
+    date_from?: string;
+    date_to?: string;
+  } = {},
+): Promise<{
+  success: boolean;
+  data?: PaginatedActivitiesResponse;
+  error?: string;
+  statusCode?: number;
+}> => {
+  try {
+    const data = await getAdminActivitiesCore(options);
+    return { success: true, data };
+  } catch (error) {
+    console.error("Error getting admin activities:", error);
+    return {
+      success: false,
+      error: "Failed to get admin activities",
+      statusCode: 500,
+    };
+  }
+};
 
 /**
  * Get single admin report detail

--- a/apps/api/src/routes/admin/types.ts
+++ b/apps/api/src/routes/admin/types.ts
@@ -83,6 +83,43 @@ export const AdminActionLogSchema = z.object({
   created_at: z.string(),
 });
 
+// Admin Activities Query Params
+export const AdminActivitiesQuerySchema = z.object({
+  page: z
+    .string()
+    .optional()
+    .transform((val) => parseInt(val || "1")),
+  limit: z
+    .string()
+    .optional()
+    .transform((val) => parseInt(val || "20")),
+  action_type: z.string().optional(),
+  admin_user_id: z.string().optional(),
+  date_from: z.string().optional(),
+  date_to: z.string().optional(),
+});
+
+// Admin Activity Item (with admin name from join)
+export const AdminActivityItemSchema = z.object({
+  id: z.string(),
+  admin_user_id: z.string(),
+  admin_user_name: z.string(),
+  action_type: z.string(),
+  target_type: z.string(),
+  target_id: z.string(),
+  details: z.any().nullable(),
+  created_at: z.string(),
+});
+
+// Paginated Activities Response
+export const PaginatedActivitiesResponseSchema = z.object({
+  items: z.array(AdminActivityItemSchema),
+  total: z.number(),
+  page: z.number(),
+  limit: z.number(),
+  pages: z.number(),
+});
+
 // TypeScript types from Zod schemas
 export type AdminStatsResponse = z.infer<typeof AdminStatsResponseSchema>;
 export type AdminReportsResponse = z.infer<typeof AdminReportsResponseSchema>;
@@ -93,6 +130,10 @@ export type AdminReportActionResponse = z.infer<
   typeof AdminReportActionResponseSchema
 >;
 export type AdminActionLog = z.infer<typeof AdminActionLogSchema>;
+export type AdminActivityItem = z.infer<typeof AdminActivityItemSchema>;
+export type PaginatedActivitiesResponse = z.infer<
+  typeof PaginatedActivitiesResponseSchema
+>;
 
 // Database interfaces
 export interface AdminAction {

--- a/apps/web/app/admin/activity/page.tsx
+++ b/apps/web/app/admin/activity/page.tsx
@@ -1,0 +1,42 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@repo/ui/components/ui/card";
+import { AdminActivityTable } from "@/components/admin/admin-activity-table";
+
+export default function AdminActivityPage() {
+  return (
+    <div className="min-h-screen bg-neutral-100">
+      <div className="container mx-auto px-4 py-8">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="mb-2 text-4xl font-bold tracking-tight text-neutral-900">
+            Log Aktivitas
+          </h1>
+          <p className="text-lg text-neutral-600">
+            Pantau semua aksi admin pada laporan dan pengguna
+          </p>
+        </div>
+
+        {/* Activity Table */}
+        <Card className="border border-neutral-200 bg-white shadow-md">
+          <CardHeader className="border-b border-neutral-200 bg-neutral-50">
+            <CardTitle className="text-xl font-semibold text-neutral-900">
+              Riwayat Aktivitas
+            </CardTitle>
+            <CardDescription className="text-neutral-600">
+              Log lengkap semua aksi verifikasi, penolakan, dan pengelolaan
+              laporan
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="p-6">
+            <AdminActivityTable />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/admin/admin-activity-table.tsx
+++ b/apps/web/components/admin/admin-activity-table.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import * as React from "react";
+import {
+  useReactTable,
+  getCoreRowModel,
+  flexRender,
+  type ColumnDef,
+} from "@tanstack/react-table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@repo/ui/components/ui/table";
+import { Button } from "@repo/ui/components/ui/button";
+import { Badge } from "@repo/ui/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/components/ui/select";
+import { Input } from "@repo/ui/components/ui/input";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Loader2,
+  Activity,
+  AlertCircle,
+} from "lucide-react";
+import {
+  useAdminActivitiesQuery,
+  type AdminActivityItem,
+} from "../../hooks/admin/use-admin-activities";
+
+const ACTION_TYPE_CONFIG: Record<
+  string,
+  {
+    label: string;
+    variant: "default" | "secondary" | "destructive" | "outline";
+  }
+> = {
+  verify_report: { label: "Verifikasi", variant: "default" },
+  reject_report: { label: "Tolak", variant: "destructive" },
+  delete_report: { label: "Hapus", variant: "secondary" },
+  restore_report: { label: "Pulihkan", variant: "outline" },
+  toggle_report_status: { label: "Ubah Status", variant: "outline" },
+  change_user_role: { label: "Ubah Role", variant: "secondary" },
+};
+
+const getActionBadge = (actionType: string) => {
+  const config = ACTION_TYPE_CONFIG[actionType] || {
+    label: actionType,
+    variant: "outline" as const,
+  };
+  return <Badge variant={config.variant}>{config.label}</Badge>;
+};
+
+const formatTimestamp = (timestamp: string) => {
+  const date = new Date(timestamp);
+  return date.toLocaleDateString("id-ID", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
+const formatDetails = (details: Record<string, unknown> | null): string => {
+  if (!details) return "-";
+  const parts: string[] = [];
+  if (details.previous_status) parts.push(`dari: ${details.previous_status}`);
+  if (details.new_status) parts.push(`ke: ${details.new_status}`);
+  if (details.reason) parts.push(`alasan: ${details.reason}`);
+  if (details.new_role) parts.push(`role: ${details.new_role}`);
+  return parts.length > 0 ? parts.join(", ") : "-";
+};
+
+const columns: ColumnDef<AdminActivityItem>[] = [
+  {
+    accessorKey: "created_at",
+    header: "Waktu",
+    cell: ({ row }) => (
+      <span className="text-sm whitespace-nowrap text-neutral-600">
+        {formatTimestamp(row.original.created_at)}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "admin_user_name",
+    header: "Admin",
+    cell: ({ row }) => (
+      <span className="font-medium text-neutral-900">
+        {row.original.admin_user_name}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "action_type",
+    header: "Aksi",
+    cell: ({ row }) => getActionBadge(row.original.action_type),
+  },
+  {
+    accessorKey: "target_type",
+    header: "Target",
+    cell: ({ row }) => (
+      <span className="text-sm text-neutral-600">
+        {row.original.target_type}:{" "}
+        <span className="font-mono text-xs">
+          {row.original.target_id.slice(0, 8)}...
+        </span>
+      </span>
+    ),
+  },
+  {
+    accessorKey: "details",
+    header: "Detail",
+    cell: ({ row }) => (
+      <span className="text-sm text-neutral-500">
+        {formatDetails(row.original.details)}
+      </span>
+    ),
+  },
+];
+
+export const AdminActivityTable = () => {
+  const [page, setPage] = React.useState(1);
+  const [actionTypeFilter, setActionTypeFilter] = React.useState<string>("");
+  const [dateFrom, setDateFrom] = React.useState("");
+  const [dateTo, setDateTo] = React.useState("");
+  const limit = 20;
+
+  const { data, isLoading, isError, error } = useAdminActivitiesQuery({
+    page,
+    limit,
+    action_type: actionTypeFilter || undefined,
+    date_from: dateFrom || undefined,
+    date_to: dateTo || undefined,
+  });
+
+  const table = useReactTable({
+    data: data?.items ?? [],
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+    pageCount: data?.pages ?? 0,
+  });
+
+  const handleResetFilters = () => {
+    setActionTypeFilter("");
+    setDateFrom("");
+    setDateTo("");
+    setPage(1);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="mr-2 h-5 w-5 animate-spin text-neutral-500" />
+        <span className="text-neutral-500">Memuat aktivitas...</span>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-center py-12 text-red-600">
+        <AlertCircle className="mr-2 h-5 w-5" />
+        <span>Gagal memuat: {error?.message}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Select
+          value={actionTypeFilter}
+          onValueChange={(value) => {
+            setActionTypeFilter(value === "all" ? "" : value);
+            setPage(1);
+          }}
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Semua Aksi" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Semua Aksi</SelectItem>
+            <SelectItem value="verify_report">Verifikasi</SelectItem>
+            <SelectItem value="reject_report">Tolak</SelectItem>
+            <SelectItem value="delete_report">Hapus</SelectItem>
+            <SelectItem value="restore_report">Pulihkan</SelectItem>
+            <SelectItem value="toggle_report_status">Ubah Status</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Input
+          type="date"
+          value={dateFrom}
+          onChange={(e) => {
+            setDateFrom(e.target.value);
+            setPage(1);
+          }}
+          className="w-[160px]"
+          placeholder="Dari tanggal"
+        />
+        <Input
+          type="date"
+          value={dateTo}
+          onChange={(e) => {
+            setDateTo(e.target.value);
+            setPage(1);
+          }}
+          className="w-[160px]"
+          placeholder="Sampai tanggal"
+        />
+
+        {(actionTypeFilter || dateFrom || dateTo) && (
+          <Button variant="ghost" size="sm" onClick={handleResetFilters}>
+            Reset
+          </Button>
+        )}
+
+        <span className="ml-auto text-sm text-neutral-500">
+          {data?.total ?? 0} aktivitas
+        </span>
+      </div>
+
+      {/* Table */}
+      <div className="rounded-md border border-neutral-200">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id} className="bg-neutral-50">
+                {headerGroup.headers.map((header) => (
+                  <TableHead
+                    key={header.id}
+                    className="font-semibold text-neutral-700"
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length > 0 ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} className="hover:bg-neutral-50">
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="py-12 text-center"
+                >
+                  <Activity className="mx-auto mb-3 h-8 w-8 text-neutral-300" />
+                  <p className="text-neutral-500">Belum ada aktivitas admin</p>
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      {(data?.pages ?? 0) > 1 && (
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-neutral-500">
+            Halaman {data?.page} dari {data?.pages}
+          </span>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page <= 1}
+            >
+              <ChevronLeft className="mr-1 h-4 w-4" />
+              Sebelumnya
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => p + 1)}
+              disabled={page >= (data?.pages ?? 1)}
+            >
+              Selanjutnya
+              <ChevronRight className="ml-1 h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/web/components/admin/admin-navigation.tsx
+++ b/apps/web/components/admin/admin-navigation.tsx
@@ -20,6 +20,7 @@ import {
   LayoutDashboard,
   FileText,
   Users,
+  Activity,
   ChevronUp,
   LogOut,
 } from "lucide-react";
@@ -52,6 +53,11 @@ export const AdminNavigation = () => {
       href: "/admin/users",
       label: "Pengguna",
       icon: Users,
+    },
+    {
+      href: "/admin/activity",
+      label: "Aktivitas",
+      icon: Activity,
     },
   ];
 

--- a/apps/web/components/admin/index.ts
+++ b/apps/web/components/admin/index.ts
@@ -4,3 +4,4 @@ export { AdminReportsTableWrapper } from "./admin-reports-table-wrapper";
 export { AdminUsersTable } from "./admin-users-table";
 export { AdminUsersTableWrapper } from "./admin-users-table-wrapper";
 export { AdminReportDetail } from "./admin-report-detail";
+export { AdminActivityTable } from "./admin-activity-table";

--- a/apps/web/components/sharing/share-dialog.tsx
+++ b/apps/web/components/sharing/share-dialog.tsx
@@ -24,7 +24,6 @@ import {
   SharingPreview,
   SharingActions,
 } from "./index";
-import type { GenerateAICaptionRequest } from "@/services/api-client";
 
 interface ShareDialogProps {
   isOpen: boolean;

--- a/apps/web/hooks/admin/use-admin-activities.ts
+++ b/apps/web/hooks/admin/use-admin-activities.ts
@@ -1,0 +1,77 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuthContext } from "../../contexts/AuthContext";
+
+export interface AdminActivityItem {
+  id: string;
+  admin_user_id: string;
+  admin_user_name: string;
+  action_type: string;
+  target_type: string;
+  target_id: string;
+  details: Record<string, unknown> | null;
+  created_at: string;
+}
+
+interface PaginatedActivitiesResponse {
+  items: AdminActivityItem[];
+  total: number;
+  page: number;
+  limit: number;
+  pages: number;
+}
+
+interface UseAdminActivitiesOptions {
+  page?: number;
+  limit?: number;
+  action_type?: string;
+  date_from?: string;
+  date_to?: string;
+}
+
+export const useAdminActivitiesQuery = (
+  options: UseAdminActivitiesOptions = {},
+) => {
+  const { getToken, isAuthenticated, backendUser } = useAuthContext();
+  const { page = 1, limit = 20, action_type, date_from, date_to } = options;
+
+  return useQuery({
+    queryKey: ["adminActivities", page, limit, action_type, date_from, date_to],
+    queryFn: async (): Promise<PaginatedActivitiesResponse> => {
+      const token = await getToken();
+      if (!token) {
+        throw new Error("Authentication required");
+      }
+
+      const API_BASE_URL =
+        process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
+
+      const params = new URLSearchParams();
+      params.set("page", String(page));
+      params.set("limit", String(limit));
+      if (action_type) params.set("action_type", action_type);
+      if (date_from) params.set("date_from", date_from);
+      if (date_to) params.set("date_to", date_to);
+
+      const response = await fetch(
+        `${API_BASE_URL}/api/admin/activities?${params.toString()}`,
+        {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+        },
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error?.message || `HTTP ${response.status}`);
+      }
+
+      return response.json();
+    },
+    enabled: isAuthenticated && !!backendUser,
+    staleTime: 2 * 60 * 1000, // 2 minutes (activities change more often)
+    gcTime: 5 * 60 * 1000,
+  });
+};


### PR DESCRIPTION
## Summary
- Add `GET /api/admin/activities` endpoint with pagination and filters (action_type, date_from, date_to)
- Add `/admin/activity` page with TanStack Table showing all admin actions (verify, reject, delete, restore, toggle)
- Action type badges with color coding, date range filters, and pagination
- Add "Aktivitas" nav item to admin navigation
- Fix pre-existing duplicate import in share-dialog.tsx

## Architecture
Follows existing 4-layer pattern:
- **types.ts**: `AdminActivitiesQuerySchema`, `PaginatedActivitiesResponseSchema`, `AdminActivityItemSchema`
- **core.ts**: `getAdminActivities()` — paginated SQL query with dynamic WHERE clauses via `sql.unsafe`
- **shell.ts**: `getAdminActivitiesShell()` — error handling wrapper
- **api.ts**: OpenAPI route definition + handler

Frontend:
- **use-admin-activities.ts**: React Query hook with filter params in query key
- **admin-activity-table.tsx**: TanStack Table with action type filter, date range inputs, pagination
- **activity/page.tsx**: Server component page at `/admin/activity`

## Test plan
- [ ] Visit `/admin/activity` — verify table loads with activity data
- [ ] Filter by action type (Verifikasi, Tolak, etc.) — verify correct filtering
- [ ] Set date range — verify results scoped to range
- [ ] Test pagination with 20+ activities
- [ ] Verify "Aktivitas" nav item appears and highlights when active
- [ ] Run `bun run format && bun run lint && bun run check-types && cd apps/api && bun test`

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)