### PR TITLE
fix: restore VPS deployment pipeline

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -6,6 +6,7 @@ on:
       - main
 
 permissions:
+  contents: read
   packages: write
 
 jobs:
@@ -143,48 +144,60 @@ jobs:
               exit 1
             fi
 
+            COMPOSE="docker compose -f docker-compose.prod.yml --env-file .env.production"
+
+            # Ensure external 'edge' network exists (used by caddy reverse proxy)
+            docker network create edge || true
+
             # Prepare deployment
             echo "🚀 Preparing deployment..."
-            docker-compose -f docker-compose.prod.yml --env-file .env.production down || true
 
             # Start only the DB so we can run migrations against it
-            docker-compose -f docker-compose.prod.yml --env-file .env.production up -d db
+            $COMPOSE up -d db
 
             # Wait for Postgres to be ready
             echo "⏳ Waiting for Postgres to be ready..."
             for i in $(seq 1 30); do
-              docker-compose -f docker-compose.prod.yml --env-file .env.production exec -T db pg_isready -U postgres &>/dev/null && { echo "✅ Postgres is ready"; break; }
+              $COMPOSE exec -T db pg_isready -U postgres &>/dev/null && { echo "✅ Postgres is ready"; break; }
               [ $i -eq 30 ] && echo "❌ Postgres failed to start" && exit 1
               echo "Waiting for Postgres... attempt $i/30"
               sleep 2
             done
 
             # Ensure PostGIS extension exists (best-effort)
-            docker-compose -f docker-compose.prod.yml --env-file .env.production exec -T db psql -U postgres -d viralkan -c "CREATE EXTENSION IF NOT EXISTS postgis;" || echo "⚠️  Warning: couldn't create postgis extension"
+            $COMPOSE exec -T db psql -U postgres -d viralkan -c "CREATE EXTENSION IF NOT EXISTS postgis;" || echo "⚠️  Warning: couldn't create postgis extension"
 
             # Run database migrations (idempotent) every deploy
             echo "🔄 Running database migrations..."
-            docker run --rm --network viralkan-private --env-file .env.production ghcr.io/${{ github.repository }}/viralkan-api:${{ needs.commit-hash.outputs.commit_hash }} bun run db:migrate || {
+            docker run --rm \
+              --network viralkan-private \
+              --env-file .env.production \
+              -e DATABASE_URL="postgresql://postgres:${DB_PASSWORD}@db:5432/viralkan" \
+              ghcr.io/${{ github.repository }}/viralkan-api:${{ needs.commit-hash.outputs.commit_hash }} \
+              bun run db:migrate || {
               echo "❌ Migrations failed" >&2
-              docker-compose -f docker-compose.prod.yml --env-file .env.production logs --tail=100 db
+              $COMPOSE logs --tail=100 db
               exit 1
             }
 
-            # Ensure external 'edge' network exists (used by caddy reverse proxy)
-            docker network create edge || true
-
             # Bring up remaining services
             echo "🌐 Starting API and Web services..."
-            docker-compose -f docker-compose.prod.yml --env-file .env.production up -d
+            $COMPOSE up -d
 
             # Wait for API to be healthy
             echo "⏳ Waiting for API to be ready..."
+            api_container="$($COMPOSE ps -q api)"
             for i in $(seq 1 30); do
-              curl -s http://localhost:3000/health &>/dev/null && { echo "✅ API is healthy"; break; }
-              [ $i -eq 30 ] && echo "⚠️  API health check timed out (may still be starting)"
+              api_status="$(docker inspect -f '{{.State.Health.Status}}' "$api_container" 2>/dev/null || true)"
+              [ "$api_status" = "healthy" ] && { echo "✅ API container is healthy"; break; }
+              [ $i -eq 30 ] && echo "❌ API health check timed out" && $COMPOSE logs --tail=100 api && exit 1
               echo "Waiting for API... attempt $i/30"
               sleep 2
             done
+
+            echo "🔎 Verifying public routes through Caddy..."
+            curl -fsS https://viral-api.faldi.xyz/ >/dev/null
+            curl -fsSI https://viral.faldi.xyz/ >/dev/null
 
             # Clean up old images
             echo "🧹 Cleaning up old Docker images..."

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,9 +1,10 @@
-FROM oven/bun:1.2.6 AS base
+FROM node:22-bookworm-slim AS node
 
-# Install wget for health checks (Debian-based official Bun image)
-USER root
-RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certificates \
-  && rm -rf /var/lib/apt/lists/*
+FROM oven/bun:1.2.4 AS base
+
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+
+RUN node --version && bun --version
 
 FROM base AS builder
 WORKDIR /app
@@ -12,12 +13,14 @@ WORKDIR /app
 COPY package.json ./
 COPY bun.lock ./
 
-# Copy the web package.json and packages
+# Copy workspace manifests and packages
+COPY apps/api/package.json ./apps/api/package.json
+COPY apps/docs/package.json ./apps/docs/package.json
 COPY apps/web/package.json ./apps/web/package.json
 COPY packages ./packages
 
 # Install dependencies
-RUN bun install
+RUN bun install --frozen-lockfile
 
 # Copy app source
 COPY . .
@@ -43,7 +46,7 @@ ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 # Build the web app
 RUN cd apps/web && bun run build
 
-FROM base AS runner
+FROM node:22-bookworm-slim AS runner
 WORKDIR /app
 
 # Don't run production as root
@@ -61,5 +64,4 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-# Use the working path but with Bun instead of Node
-CMD ["bun", "apps/web/server.js"]
+CMD ["node", "apps/web/server.js"]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": " next dev --turbopack --port 5173",
-    "build": " next build",
+    "dev": "next dev --webpack --port 5173",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint . --max-warnings 0",
     "check-types": "tsc --noEmit"


### PR DESCRIPTION
## What Change
- Force the Next.js web app to build with webpack because Next.js 16 defaults to Turbopack and the PWA plugin adds webpack config.
- Build the web Docker image with real Node available for Next.js, while still using Bun for dependency install.
- Harden the VPS deploy workflow by keeping the stack up during migration, passing the in-compose DATABASE_URL to migrations, waiting on Docker health, and verifying public Caddy routes.

## Why Change
- The latest main CI failed on `next build` with the Next.js 16 Turbopack/webpack config error.
- The web Docker build path also ran Next under Bun's Node shim, which produced unsupported worker_threads errors and no standalone output.
- The deploy script checked localhost on the VPS even though services are exposed through Docker/Caddy.

## Impact
- CI and image builds can produce the web standalone output again.
- Main deploys should update the VPS without tearing down the DB/API first.
- Deployment now fails loudly if API container health or public VPS routes are not accessible.